### PR TITLE
Add `debug` as a normal dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
     }
   ],
   "dependencies": {
+    "debug": "^2.1.0",
     "lodash": "^2.4.1",
     "nano": "^6.0.2"
   },
   "devDependencies": {
-    "debug": "^2.1.0",
     "grunt": "^0.4.5",
     "grunt-contrib-coffee": "^0.12.0"
   },


### PR DESCRIPTION
The module actually depends on the `debug` package, but it's only included as a `devDependency`, so the connector can't be loaded when called by loopback.

This fixes Issue #1.
