### PR TITLE
Fix `isRelational` not getting set properly.

### DIFF
--- a/lib/couch.js
+++ b/lib/couch.js
@@ -83,7 +83,7 @@
         this._metaData = {
           types: this.getTypes(),
           defaultIdType: this.getDefaultIdType(),
-          isRelational: this.isRelational,
+          isRelational: this.relational,
           schemaForSettings: {}
         };
       }


### PR DESCRIPTION
Although in this case, `undefined` might end up being interpreted the same way as `false`, it's technically still a bug.
